### PR TITLE
Add default parameters and docstring to display method

### DIFF
--- a/obocar.py
+++ b/obocar.py
@@ -385,7 +385,6 @@ class OBOCar:
         self.IA2.duty(0)
         self.IB2.duty(speed)
 
-
         
     def move_backward(self, speed=512):  # Default speed set to half
         
@@ -430,7 +429,13 @@ class OBOCar:
     def play_sequence(self, tones):
         self.buzzer.play_sequence(tones)
         
-    def display(self, message,x,y):
+    def display(self, message, x=0, y=0):
+        """
+        Display a message on the OLED screen.
+        message: The message to display
+        x: The x-coordinate of the message (default is 0)
+        y: The y-coordinate of the message (default is 0)
+        """
         if self.OLED:
             self.OLED.fill(0)  # Clear the display
             self.OLED.text(message, x, y, 1)  # Display message


### PR DESCRIPTION
### What changed?

- Added default values (x=0, y=0) to the display method parameters
- Added docstring to the display method explaining its purpose and parameters
- Removed an extra blank line in the right_motor_backward method

### How to test?

```
from obocar import OBOCar
car = OBOCar()
car.display("Test")
```

### Why make this change?

This change improves the usability of the display method by providing sensible defaults, allowing users to call the method with just a message parameter. The added documentation helps developers understand the purpose and parameters of the method, making the code more maintainable and easier to use.